### PR TITLE
Enable support for QSA in mod_rewrite style config

### DIFF
--- a/src/main/java/org/tuckey/web/filters/urlrewrite/utils/ModRewriteConfLoader.java
+++ b/src/main/java/org/tuckey/web/filters/urlrewrite/utils/ModRewriteConfLoader.java
@@ -322,7 +322,7 @@ public class ModRewriteConfLoader {
                 This flag forces the rewrite engine to append a query string part of the substitution string to the existing string, instead of replacing it. Use this when you want to add more data to the query string via a rewrite rule.
                 */
                 if ("qsappend".equalsIgnoreCase(flag) || "QSA".equalsIgnoreCase(flag)) {
-                    log.info("qsappend flag [QSA] not supported");
+                    rule.setQueryStringAppend("true");
                 }
                 /*
                 # 'redirect|R [=code]' (force redirect)


### PR DESCRIPTION
Hi (thanks for this library - much appreciated here!)

I'm looking to use the mod_rewrite style config and noticed that appending the query string didn't seem to be supported for this style of configuration.  It looks like the underlying NormalRule implementation does support it, so this pull request enables it.

Not sure if there was a reason for this not being enabled... couldn't find any tests around this config style.  

Let me know what you think

J