### PR TITLE
Migrate to from httpclient-3.1 to httpcomponents-httpclient-4.3.3+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,9 +47,9 @@
     </licenses>
 
     <scm>
-        <url>https://github.com/paultuckey/urlrewritefilter</url>
-        <connection>scm:git:git://github.com/paultuckey/urlrewritefilter.git</connection>
-        <developerConnection>scm:git:git@github.com:paultuckey/urlrewritefilter.git</developerConnection>
+        <url>https://github.com/E-IS/urlrewritefilter</url>
+        <connection>scm:git:git://github.com/E-IS/urlrewritefilter.git</connection>
+        <developerConnection>scm:git:git@github.com:E-IS/urlrewritefilter.git</developerConnection>
     </scm>
 
     <developers>
@@ -59,7 +59,7 @@
     </developers>
 
     <issueManagement>
-        <url>https://github.com/paultuckey/urlrewritefilter/issues</url>
+        <url>https://github.com/E-IS/urlrewritefilter/issues</url>
     </issueManagement>
 
     <build>
@@ -90,7 +90,7 @@
                 <version>1.1</version>
                 <executions>
                     <execution>
-                        <phase>validate</phase>
+                        <phase>initialize</phase>
                         <goals>
                             <goal>create</goal>
                         </goals>
@@ -105,7 +105,7 @@
                 <artifactId>maven-release-plugin</artifactId>
                 <version>2.1</version>
                 <configuration>
-                    <tagBase>https://github.com/paultuckey/urlrewritefilter/tags</tagBase>
+                    <tagBase>https://github.com/E-IS/urlrewritefilter/tags</tagBase>
                 </configuration>
             </plugin>
             <plugin>
@@ -151,6 +151,26 @@
                 <artifactId>maven-site-plugin</artifactId>
                 <version>3.1</version>
             </plugin>
+
+            <plugin>
+                <groupId>org.nuiton</groupId>
+                <artifactId>helper-maven-plugin</artifactId>
+                <version>2.2.1</version>
+                <executions>
+                    <execution>
+                        <id>get-pgp-passphrase</id>
+                        <goals>
+                            <goal>share-server-secret</goal>
+                        </goals>
+                        <phase>validate</phase>
+                        <configuration>
+                            <serverId>ossrh-gpg-signer</serverId>
+                            <usernameOut>gpg.keyname</usernameOut>
+                            <passwordOut>gpg.passphrase</passwordOut>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 
@@ -168,9 +188,9 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>commons-httpclient</groupId>
-            <artifactId>commons-httpclient</artifactId>
-            <version>3.1</version>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.3.3</version>
             <scope>compile</scope>
             <optional>true</optional>
         </dependency>

--- a/src/main/java/org/tuckey/web/filters/urlrewrite/RequestProxy.java
+++ b/src/main/java/org/tuckey/web/filters/urlrewrite/RequestProxy.java
@@ -34,17 +34,15 @@
  */
 package org.tuckey.web.filters.urlrewrite;
 
-import org.apache.commons.httpclient.Header;
-import org.apache.commons.httpclient.HostConfiguration;
-import org.apache.commons.httpclient.HttpClient;
-import org.apache.commons.httpclient.HttpMethod;
-import org.apache.commons.httpclient.ProxyHost;
-import org.apache.commons.httpclient.SimpleHttpConnectionManager;
-import org.apache.commons.httpclient.methods.EntityEnclosingMethod;
-import org.apache.commons.httpclient.methods.GetMethod;
-import org.apache.commons.httpclient.methods.InputStreamRequestEntity;
-import org.apache.commons.httpclient.methods.PostMethod;
-import org.apache.commons.httpclient.methods.RequestEntity;
+import org.apache.http.*;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.*;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.InputStreamEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.conn.BasicHttpClientConnectionManager;
+import org.apache.http.util.EntityUtils;
 import org.tuckey.web.filters.urlrewrite.utils.Log;
 import org.tuckey.web.filters.urlrewrite.utils.StringUtils;
 
@@ -54,6 +52,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.MalformedURLException;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Enumeration;
 
@@ -91,7 +90,7 @@ public class RequestProxy {
         }
 
         log.info("checking url");
-        final URL url;
+        URL url;
         try {
             url = new URL(target);
         } catch (MalformedURLException e) {
@@ -99,55 +98,68 @@ public class RequestProxy {
             return;
         }
 
-        log.info("seting up the host configuration");
+        log.info("setting up the host configuration");
 
-        final HostConfiguration config = new HostConfiguration();
+        RequestConfig.Builder configBuilder = RequestConfig.custom();
 
-        ProxyHost proxyHost = getUseProxyServer((String) hsRequest.getAttribute("use-proxy"));
-        if (proxyHost != null) config.setProxyHost(proxyHost);
-
-        final int port = url.getPort() != -1 ? url.getPort() : url.getDefaultPort();
-        config.setHost(url.getHost(), port, url.getProtocol());
-
+        HttpHost proxyHost = getUseProxyServer((String) hsRequest.getAttribute("use-proxy"));
+        if (proxyHost != null) configBuilder.setProxy(proxyHost);
+        RequestConfig config = configBuilder.build();
         if ( log.isInfoEnabled() ) log.info("config is " + config.toString());
 
-        final HttpMethod targetRequest = setupProxyRequest(hsRequest, url);
+        final int port = url.getPort() != -1 ? url.getPort() : url.getDefaultPort();
+        url = new URL( url.getProtocol(), url.getHost(), port, url.getFile());
+
+        final HttpRequestBase targetRequest = setupProxyRequest(hsRequest, url);
         if (targetRequest == null) {
             log.error("Unsupported request method found: " + hsRequest.getMethod());
             return;
         }
 
-        //perform the reqeust to the target server
-        final HttpClient client = new HttpClient(new SimpleHttpConnectionManager());
-        if (log.isInfoEnabled()) {
-            log.info("client state" + client.getState());
-            log.info("client params" + client.getParams().toString());
-            log.info("executeMethod / fetching data ...");
+        //perform the request to the target server
+        CloseableHttpClient client = null;
+        CloseableHttpResponse response = null;
+         try {
+            client = HttpClients.custom()
+                     .setDefaultRequestConfig(config)
+                     .setConnectionManager(new BasicHttpClientConnectionManager())
+                     .build();
+            if (log.isInfoEnabled()) {
+                log.info("executeMethod / fetching data ...");
+            }
+
+            if (targetRequest instanceof HttpEntityEnclosingRequestBase) {
+                final InputStreamEntity entity = new InputStreamEntity(
+                        hsRequest.getInputStream(), hsRequest.getContentLength(), ContentType.create(hsRequest.getContentType()));
+                final HttpEntityEnclosingRequestBase entityEnclosingMethod = (HttpEntityEnclosingRequestBase) targetRequest;
+                entityEnclosingMethod.setEntity(entity);
+                response = client.execute(entityEnclosingMethod);
+
+            } else {
+                response = client.execute(targetRequest);
+            }
+
+            //copy the target response headers to our response
+            setupResponseHeaders(targetRequest, response, hsResponse);
+
+            InputStream originalResponseStream = response.getEntity().getContent();
+            //the body might be null, i.e. for responses with cache-headers which leave out the body
+            if (originalResponseStream != null) {
+                OutputStream responseStream = hsResponse.getOutputStream();
+                copyStream(originalResponseStream, responseStream);
+            }
+            EntityUtils.consume(response.getEntity());
+
+            log.info("set up response, result code was " + response.getStatusLine().getStatusCode());
         }
-
-        final int result;
-        if (targetRequest instanceof EntityEnclosingMethod) {
-            final RequestProxyCustomRequestEntity requestEntity = new RequestProxyCustomRequestEntity(
-                    hsRequest.getInputStream(), hsRequest.getContentLength(), hsRequest.getContentType());
-            final EntityEnclosingMethod entityEnclosingMethod = (EntityEnclosingMethod) targetRequest;
-            entityEnclosingMethod.setRequestEntity(requestEntity);
-            result = client.executeMethod(config, entityEnclosingMethod);
-
-        } else {
-            result = client.executeMethod(config, targetRequest);
+        finally {
+            if (response != null) {
+                response.close();
+            }
+            if (client != null) {
+                client.close();
+            }
         }
-
-        //copy the target response headers to our response
-        setupResponseHeaders(targetRequest, hsResponse);
-
-        InputStream originalResponseStream = targetRequest.getResponseBodyAsStream();
-        //the body might be null, i.e. for responses with cache-headers which leave out the body
-        if (originalResponseStream != null) {
-            OutputStream responseStream = hsResponse.getOutputStream();
-            copyStream(originalResponseStream, responseStream);
-        }
-
-        log.info("set up response, result code was " + result);
     }
 
     public static void copyStream(InputStream in, OutputStream out) throws IOException {
@@ -159,8 +171,8 @@ public class RequestProxy {
     }
 
 
-    public static ProxyHost getUseProxyServer(String useProxyServer) {
-        ProxyHost proxyHost = null;
+    public static HttpHost getUseProxyServer(String useProxyServer) {
+        HttpHost proxyHost = null;
         if (useProxyServer != null) {
             String proxyHostStr = useProxyServer;
             int colonIdx = proxyHostStr.indexOf(':');
@@ -169,35 +181,43 @@ public class RequestProxy {
                 String proxyPortStr = useProxyServer.substring(colonIdx + 1);
                 if (proxyPortStr != null && proxyPortStr.length() > 0 && proxyPortStr.matches("[0-9]+")) {
                     int proxyPort = Integer.parseInt(proxyPortStr);
-                    proxyHost = new ProxyHost(proxyHostStr, proxyPort);
+                    proxyHost = new HttpHost(proxyHostStr, proxyPort);
                 } else {
-                    proxyHost = new ProxyHost(proxyHostStr);
+                    proxyHost = new HttpHost(proxyHostStr, 80/*default port*/);
                 }
             } else {
-                proxyHost = new ProxyHost(proxyHostStr);
+                proxyHost = new HttpHost(proxyHostStr);
             }
         }
         return proxyHost;
     }
 
-    private static HttpMethod setupProxyRequest(final HttpServletRequest hsRequest, final URL targetUrl) throws IOException {
+    private static HttpRequestBase setupProxyRequest(final HttpServletRequest hsRequest, final URL targetUrl) throws IOException {
         final String methodName = hsRequest.getMethod();
-        final HttpMethod method;
+        final HttpRequestBase method;
         if ("POST".equalsIgnoreCase(methodName)) {
-            PostMethod postMethod = new PostMethod();
-            InputStreamRequestEntity inputStreamRequestEntity = new InputStreamRequestEntity(hsRequest.getInputStream());
-            postMethod.setRequestEntity(inputStreamRequestEntity);
+            HttpPost postMethod = new HttpPost();
+            HttpEntity inputStreamRequestEntity = new InputStreamEntity(hsRequest.getInputStream());
+            postMethod.setEntity(inputStreamRequestEntity);
             method = postMethod;
         } else if ("GET".equalsIgnoreCase(methodName)) {
-            method = new GetMethod();
+            method = new HttpGet();
         } else {
             log.warn("Unsupported HTTP method requested: " + hsRequest.getMethod());
             return null;
         }
 
-        method.setFollowRedirects(false);
-        method.setPath(targetUrl.getPath());
-        method.setQueryString(targetUrl.getQuery());
+        RequestConfig config = RequestConfig.custom()
+                .setRedirectsEnabled(true)
+                .build();
+
+        method.setConfig(config);
+        try {
+            method.setURI(targetUrl.toURI());
+        }
+        catch(URISyntaxException e) {
+            throw new IOException(e);
+        }
 
         Enumeration e = hsRequest.getHeaderNames();
         if (e != null) {
@@ -223,26 +243,26 @@ public class RequestProxy {
                 while (values.hasMoreElements()) {
                     String headerValue = (String) values.nextElement();
                     log.info("setting proxy request parameter:" + headerName + ", value: " + headerValue);
-                    method.addRequestHeader(headerName, headerValue);
+                    method.addHeader(headerName, headerValue);
                 }
             }
         }
 
-        if ( log.isInfoEnabled() ) log.info("proxy query string " + method.getQueryString());
+        if ( log.isInfoEnabled() ) log.info("proxy query string " + method.getRequestLine());
         return method;
     }
 
-    private static void setupResponseHeaders(HttpMethod httpMethod, HttpServletResponse hsResponse) {
+    private static void setupResponseHeaders(HttpRequestBase httpMethod, CloseableHttpResponse httpResponse, HttpServletResponse hsResponse) {
         if ( log.isInfoEnabled() ) {
             log.info("setupResponseHeaders");
-            log.info("status text: " + httpMethod.getStatusText());
-            log.info("status line: " + httpMethod.getStatusLine());
+            log.info("status text: " + httpResponse.getStatusLine().getReasonPhrase());
+            log.info("status line: " + httpResponse.getStatusLine().getStatusCode());
         }
 
         //filter the headers, which are copied from the proxy response. The http lib handles those itself.
         //Filtered out: the content encoding, the content length and cookies
-        for (int i = 0; i < httpMethod.getResponseHeaders().length; i++) {
-            Header h = httpMethod.getResponseHeaders()[i];
+        for (int i = 0; i < httpMethod.getAllHeaders().length; i++) {
+            Header h = httpMethod.getAllHeaders()[i];
             if ("content-encoding".equalsIgnoreCase(h.getName())) {
                 continue;
             } else if ("content-length".equalsIgnoreCase(h.getName())) {
@@ -262,50 +282,8 @@ public class RequestProxy {
         }
         //fixme what about the response footers? (httpMethod.getResponseFooters())
 
-        if (httpMethod.getStatusCode() != 200) {
-            hsResponse.setStatus(httpMethod.getStatusCode());
+        if (httpResponse.getStatusLine().getStatusCode() != 200) {
+            hsResponse.setStatus(httpResponse.getStatusLine().getStatusCode());
         }
-    }
-}
-
-/**
- * @author Gunnar Hillert
- */
-class RequestProxyCustomRequestEntity  implements RequestEntity {
-
- 	private InputStream is = null;
-	private long contentLength = 0;
-	private String contentType;
-
-    public RequestProxyCustomRequestEntity(InputStream is, long contentLength, String contentType) {
-        super();
-        this.is = is;
-        this.contentLength = contentLength;
-        this.contentType = contentType;
-    }
-
-    public boolean isRepeatable() {
-        return true;
-    }
-
-    public String getContentType() {
-        return this.contentType;
-    }
-
-    public void writeRequest(OutputStream out) throws IOException {
-
-        try {
-            int l;
-            byte[] buffer = new byte[10240];
-            while ((l = is.read(buffer)) != -1) {
-                out.write(buffer, 0, l);
-            }
-        } finally {
-            is.close();
-        }
-    }
-
-    public long getContentLength() {
-        return this.contentLength;
     }
 }

--- a/src/test/java/org/tuckey/web/filters/urlrewrite/RequestProxyTest.java
+++ b/src/test/java/org/tuckey/web/filters/urlrewrite/RequestProxyTest.java
@@ -1,9 +1,13 @@
 package org.tuckey.web.filters.urlrewrite;
 
 import junit.framework.TestCase;
+import org.tuckey.web.filters.urlrewrite.utils.Log;
+import org.tuckey.web.testhelper.MockRequest;
+import org.tuckey.web.testhelper.MockResponse;
 
 import javax.servlet.ServletException;
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 
 /**
  * @author Paul Tuckey
@@ -11,11 +15,42 @@ import java.io.IOException;
  */
 public class RequestProxyTest extends TestCase {
 
+    MockResponse response;
+    MockRequest request;
+
+    public void setUp() {
+        Log.setLevel("DEBUG");
+        response = new MockResponse();
+        request = new MockRequest();
+    }
 
     public void testUseProxyServer() throws IOException, ServletException {
         assertEquals(3128, RequestProxy.getUseProxyServer("myproxyserver:3128").getPort());
         assertEquals(80, RequestProxy.getUseProxyServer("myproxyserver:A3128").getPort());
         assertEquals("myproxyserver", RequestProxy.getUseProxyServer("myproxyserver:A3128").getHostName());
+    }
+
+
+    public void testProxyRule() throws IOException, ServletException, InvocationTargetException {
+        Conf conf = new Conf();
+        NormalRule rule = new NormalRule();
+        rule.setFrom("/path/(.*)");
+        rule.setTo("http://tuckey.org/urlrewrite/$1");
+        rule.setToType("proxy");
+        conf.addRule(rule);
+        conf.initialise();
+
+        MockRequest request = new MockRequest("/path/index.html?id=46");
+        //UrlRewriteWrappedResponse urlRewriteWrappedResponse = new UrlRewriteWrappedResponse(response, request, urlRewriter);
+
+        NormalRewrittenUrl rewrittenUrl = (NormalRewrittenUrl) rule.matches(request.getRequestURI(), request, response);
+
+        assertEquals("proxy should be default type", "proxy", rule.getToType());
+        assertEquals("http://tuckey.org/urlrewrite/index.html?id=46", rewrittenUrl.getTarget());
+
+        // This work's
+        // commented to avoid network access during unit tests
+        //RequestProxy.execute(rewrittenUrl.getTarget(), request, response);
     }
 
 


### PR DESCRIPTION
hi,
I migrate to httpclient version 4.3.3.
I think this should work for last version also (4.5 ?)

Could you integrate this modification ?
(please ignore changes in pom.xml, except for the lib version)

Maybe it's possible to keep backward compatibility with httpclient, in creation a new class RequestProxy used when classpath contains HttpClient 4.x classes ?
