### PR TITLE
request-filename condition modifications for HTML5

### DIFF
--- a/src/main/java/org/tuckey/web/filters/urlrewrite/Condition.java
+++ b/src/main/java/org/tuckey/web/filters/urlrewrite/Condition.java
@@ -263,7 +263,11 @@ public class Condition extends TypeConverter {
 
             case TYPE_REQUEST_FILENAME:
                 if ( rule.getServletContext() != null ) {
-                    String fileName = rule.getServletContext().getRealPath(hsRequest.getRequestURI());
+                	String requestURI = hsRequest.getRequestURI();
+                	if (requestURI.startsWith(hsRequest.getContextPath() + "/")){
+                		requestURI = requestURI.substring(hsRequest.getContextPath().length());
+                	}
+                    String fileName = rule.getServletContext().getRealPath(requestURI);
                     if ( log.isDebugEnabled() ) log.debug("fileName found is " + fileName);
                     return evaluateStringCondition(fileName);
                 }   else {
@@ -334,34 +338,52 @@ public class Condition extends TypeConverter {
 
 
     private ConditionMatch evaluateStringCondition(String value) {
-        if (pattern == null && value == null) {
-            log.debug("value is empty and pattern is also, condition false");
-            return evaluateBoolCondition(false);
-        }
         if ( operator == OPERATOR_IS_DIR ) {
             if ( log.isDebugEnabled() ) log.debug("checking to see if " + value + " is a directory");
+            if (value == null){
+            	return evaluateBoolCondition(false);
+            }
             File fileToCheck = new File(value);
             return evaluateBoolCondition(fileToCheck.isDirectory());
         } else if ( operator == OPERATOR_IS_FILE ) {
             if ( log.isDebugEnabled() ) log.debug("checking to see if " + value + " is a file");
+            if (value == null){
+            	return evaluateBoolCondition(false);
+            }
             File fileToCheck = new File(value);
             return evaluateBoolCondition(fileToCheck.isFile());
         } else if ( operator == OPERATOR_IS_FILE_WITH_SIZE ) {
             if ( log.isDebugEnabled() ) log.debug("checking to see if " + value + " is a file with size");
+            if (value == null){
+            	return evaluateBoolCondition(false);
+            }
             File fileToCheck = new File(value);
             return evaluateBoolCondition(fileToCheck.isFile() && fileToCheck.length() > 0);
         } else if ( operator == OPERATOR_NOT_DIR ) {
             if ( log.isDebugEnabled() ) log.debug("checking to see if " + value + " is not a directory");
+            if (value == null){
+            	return evaluateBoolCondition(true);
+            }
             File fileToCheck = new File(value);
             return evaluateBoolCondition(!fileToCheck.isDirectory());
         } else if ( operator == OPERATOR_NOT_FILE ) {
             if ( log.isDebugEnabled() ) log.debug("checking to see if " + value + " is not a file");
+            if (value == null){
+            	return evaluateBoolCondition(true);
+            }
             File fileToCheck = new File(value);
             return evaluateBoolCondition(!fileToCheck.isFile());
         } else if ( operator == OPERATOR_NOT_FILE_WITH_SIZE ) {
             if ( log.isDebugEnabled() ) log.debug("checking to see if " + value + " is not a file with size");
+            if (value == null){
+            	return evaluateBoolCondition(true);
+            }
             File fileToCheck = new File(value);
             return evaluateBoolCondition(!(fileToCheck.isFile() && fileToCheck.length() > 0));
+        }
+        if (pattern == null && value == null) {
+            log.debug("value is empty and pattern is also, condition false");
+            return evaluateBoolCondition(false);
         }
         if (pattern == null) {
             log.debug("value isn't empty but pattern is, assuming checking for existence, condition true");

--- a/src/main/java/org/tuckey/web/filters/urlrewrite/substitution/PatternReplacer.java
+++ b/src/main/java/org/tuckey/web/filters/urlrewrite/substitution/PatternReplacer.java
@@ -62,6 +62,9 @@ public class PatternReplacer implements SubstitutionFilter {
             // get out of there for wildcard patterns
             if (!conditionMatcher.isMultipleMatchingSupported())
                 break;
+            if (conditionMatcher.hitEnd()){
+				break;
+			}
         }
         // put the remaining ending non-matched string
         if (lastMatchEnd < from.length())

--- a/src/main/java/org/tuckey/web/filters/urlrewrite/utils/RegexMatcher.java
+++ b/src/main/java/org/tuckey/web/filters/urlrewrite/utils/RegexMatcher.java
@@ -92,6 +92,10 @@ public class RegexMatcher implements StringMatchingMatcher {
 	public boolean isMultipleMatchingSupported() {
 		return true;
 	}
+	
+	public boolean hitEnd(){
+		return matcher.hitEnd();
+	}
 
 
 }

--- a/src/main/java/org/tuckey/web/filters/urlrewrite/utils/StringMatchingMatcher.java
+++ b/src/main/java/org/tuckey/web/filters/urlrewrite/utils/StringMatchingMatcher.java
@@ -56,4 +56,6 @@ public interface StringMatchingMatcher {
     int groupCount();
 
     String group(int groupId);
+    
+    public boolean hitEnd();
 }


### PR DESCRIPTION
Modifications for request-filename condition to got it working well on Payara Glassfish Server.

Used and working urlrewrite.xml rule (ignored rest services url):

```
<rule>
  <name>HTML5 Redirect</name>
  <condition type="request-filename" operator="notfile"></condition>
  <condition type="request-filename" operator="notdir"></condition>
  <from>^((?!rest).)*$</from>
  <to type="redirect">/index.html</to>
</rule>
```