### PR TITLE
Removing numeric only statement notequal from docs

### DIFF
--- a/src/doc/manual/4.0/index.html
+++ b/src/doc/manual/4.0/index.html
@@ -798,8 +798,7 @@ if ( &lt;condition&gt; elements match && matcher.find() ) {
     <td><b>equal</b> (default)</td>
     <td>Equals. The operator to be used when the condition is run, the regular expression matches or the values are
         equal.</td></tr>
-<tr><td>notequal</td><td>Not equal to. (i.e. request value != condition value). Note, this operator only work with
-    numeric rule types.</td></tr>
+<tr><td>notequal</td><td>Not equal to. (i.e. request value != condition value).</td></tr>
 <tr><td>greater</td><td>Greater than. (i.e. request value &gt; condition value). Note, this operator only work with
     numeric
     rule types.</td></tr>


### PR DESCRIPTION
Fixing #200 : adjusting documentation to reflect that `notequals` takes non numeric arguments as well.