### PR TITLE
Google code repo links to this github repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,4 +51,4 @@ You can visit http://127.0.0.1:8080/rewrite-status (or whatever the address of y
 
 <a href="http://www.jetbrains.com/idea/"><img src="http://www.jetbrains.com/img/logo_bw.gif" alt="The best Java IDE" border="0"/></a> IDE Sponsored by [JetBrains](http://www.jetbrains.com/)
 
-Old repositoy http://code.google.com/p/urlrewritefilter.
+Old repository http://code.google.com/p/urlrewritefilter.

--- a/README.md
+++ b/README.md
@@ -51,4 +51,4 @@ You can visit http://127.0.0.1:8080/rewrite-status (or whatever the address of y
 
 <a href="http://www.jetbrains.com/idea/"><img src="http://www.jetbrains.com/img/logo_bw.gif" alt="The best Java IDE" border="0"/></a> IDE Sponsored by [JetBrains](http://www.jetbrains.com/)
 
-Old repository http://code.google.com/p/urlrewritefilter.
+Previously on Google Code: http://code.google.com/p/urlrewritefilter.


### PR DESCRIPTION
First, I was just correcting the spelling of "repositoy". But ten I realized that the google code repository just redirects back to this URL.

I think we should keep the link for reference, but I made it more obvious that the link "previously" worked.