### PR TITLE
isFile handles encoded URIs

### DIFF
--- a/src/main/java/org/tuckey/web/filters/urlrewrite/Condition.java
+++ b/src/main/java/org/tuckey/web/filters/urlrewrite/Condition.java
@@ -48,6 +48,8 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
 import java.io.File;
 import java.util.Calendar;
+import java.net.URI;
+import java.net.URISyntaxException;
 
 /**
  * Conditions must be met when the filter is processing a url.
@@ -267,7 +269,11 @@ public class Condition extends TypeConverter {
                 	if (requestURI.startsWith(hsRequest.getContextPath() + "/")){
                 		requestURI = requestURI.substring(hsRequest.getContextPath().length());
                 	}
-                    String fileName = rule.getServletContext().getRealPath(requestURI);
+                    // Decode any encoded URI chars
+                    try {
+                        requestURI = new URI( requestURI ).getPath();
+                    } catch( URISyntaxException URIe ) {}
+                    String fileName = rule.getServletContext().getRealPath( requestURI );
                     if ( log.isDebugEnabled() ) log.debug("fileName found is " + fileName);
                     return evaluateStringCondition(fileName);
                 }   else {

--- a/src/test/java/org/tuckey/web/filters/urlrewrite/RuleTest.java
+++ b/src/test/java/org/tuckey/web/filters/urlrewrite/RuleTest.java
@@ -820,6 +820,19 @@ public class RuleTest extends TestCase {
         assertEquals("/found-the-file", rewrittenUrl.getTarget());
     }
 
+    public void testEncodedFilename() throws InvocationTargetException, IOException, ServletException {
+        NormalRule rule = new NormalRule();
+        rule.setTo("/found-the-file");
+        Condition condition = new Condition();
+        condition.setType("request-filename");
+        condition.setOperator("isfile");
+        rule.addCondition(condition);
+        rule.initialise(new MockServletContext());
+        MockRequest request = new MockRequest("/conf%2Dtest1.xml");
+        NormalRewrittenUrl rewrittenUrl = (NormalRewrittenUrl) rule.matches(request.getRequestURI(), request, response);
+        assertEquals("/found-the-file", rewrittenUrl.getTarget());
+    }
+
     public void testNotFilename() throws InvocationTargetException, IOException, ServletException {
         NormalRule rule = new NormalRule();
         rule.setTo("/not-found-the-file");


### PR DESCRIPTION
This pull solves
https://github.com/paultuckey/urlrewritefilter/issues/226
https://github.com/paultuckey/urlrewritefilter/issues/218

When testing a request filename, the URI is now converted to a path which handles any URL encoded characters.